### PR TITLE
chore: conform to SPDX expression

### DIFF
--- a/nvml-wrapper-sys/Cargo.toml
+++ b/nvml-wrapper-sys/Cargo.toml
@@ -6,7 +6,7 @@ description = "Generated bindings to the NVIDIA Management Library."
 readme = "README.md"
 documentation = "https://docs.rs/nvml-wrapper-sys"
 repository = "https://github.com/Cldfire/nvml-wrapper"
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 edition = "2018"
 rust-version = "1.51.0"
 

--- a/nvml-wrapper/Cargo.toml
+++ b/nvml-wrapper/Cargo.toml
@@ -6,7 +6,7 @@ description = "A safe and ergonomic Rust wrapper for the NVIDIA Management Libra
 readme = "../README.md"
 documentation = "https://docs.rs/nvml-wrapper"
 repository = "https://github.com/Cldfire/nvml-wrapper"
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 edition = "2018"
 rust-version = "1.51.0"
 


### PR DESCRIPTION
The slash syntax is deprecated, according to [The Cargo Book](https://doc.rust-lang.org/cargo/reference/manifest.html#the-license-and-license-file-fields).