### PR TITLE
Add `legacy-functions` feature to wrapper and bindings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,10 @@ jobs:
         with:
           command: check
           args: --all-features
+      - uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --no-run
 
   fmt:
     name: Rustfmt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ This file describes the changes / additions / fixes between wrapper releases, tr
 ### Added
 
 * Wrapper methods are now annotated with the `#[doc(alias = "...")]` attribute to make them searchable by C function name in rustdoc ([#31](https://github.com/Cldfire/nvml-wrapper/pull/31) - @arpankapoor)
+* Some older function versions are now wrapped and available for use behind the `legacy-functions` crate feature
+  * `running_compute_processes_v2`
+  * `running_graphics_processes_v2`
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -52,8 +52,7 @@ Note that it's not advised to repeatedly call `Nvml::init` as the constructor
 has to perform all the work of loading the function symbols from the library
 each time it gets called. Instead, call `Nvml::init` once and store the resulting
 `Nvml` instance somewhere to be accessed throughout the lifetime of your program
-(perhaps in a
-[`once_cell`](https://docs.rs/once_cell/latest/once_cell/sync/struct.Lazy.html)).
+(perhaps in a [`once_cell`][once_cell]).
 
 ## NVML Support
 
@@ -61,6 +60,25 @@ This wrapper is being developed against and currently supports NVML version
 11. Each new version of NVML is guaranteed to be backwards-compatible according
 to NVIDIA, so this wrapper should continue to work without issue regardless of
 NVML version bumps.
+
+### Legacy Functions
+
+Sometimes there will be function-level API version bumps in new NVML releases.
+For example:
+
+```text
+nvmlDeviceGetComputeRunningProcesses
+nvmlDeviceGetComputeRunningProcesses_v2
+nvmlDeviceGetComputeRunningProcesses_v3
+```
+
+The older versions of the functions will generally continue to work with the
+newer NVML releases; however, the newer function versions will not work with
+older NVML installs.
+
+By default this wrapper only provides access to the newest function versions.
+Enable the `legacy-functions` feature if you require the ability to call older
+functions.
 
 ## MSRV
 
@@ -89,3 +107,4 @@ be dual licensed as above, without any additional terms or conditions.
 
 [nvml]: https://developer.nvidia.com/nvidia-management-library-nvml
 [libloading]: https://github.com/nagisa/rust_libloading
+[once_cell]: https://docs.rs/once_cell/latest/once_cell/sync/struct.Lazy.html

--- a/nvml-wrapper-sys/CHANGELOG.md
+++ b/nvml-wrapper-sys/CHANGELOG.md
@@ -6,6 +6,10 @@ This file describes the changes / additions / fixes between bindings releases.
 
 Bindings have been regenerated using the NVML 11.8 header and bindgen 0.63.0.
 
+### Added
+
+* The `legacy-functions` feature can now be enabled to access older function versions in the bindings.
+
 ## 0.6.0 (released 2022-05-26)
 
 ### Release Summary

--- a/nvml-wrapper-sys/Cargo.toml
+++ b/nvml-wrapper-sys/Cargo.toml
@@ -20,3 +20,4 @@ libloading = "0.7.0"
 
 [features]
 default = []
+legacy-functions = []

--- a/nvml-wrapper-sys/README.md
+++ b/nvml-wrapper-sys/README.md
@@ -39,6 +39,25 @@ These bindings were generated for NVML version 11. Each new version of NVML is
 guaranteed to be backwards-compatible according to NVIDIA, so these bindings
 should be useful regardless of NVML version bumps.
 
+### Legacy Functions
+
+Sometimes there will be function-level API version bumps in new NVML releases.
+For example:
+
+```text
+nvmlDeviceGetComputeRunningProcesses
+nvmlDeviceGetComputeRunningProcesses_v2
+nvmlDeviceGetComputeRunningProcesses_v3
+```
+
+The older versions of the functions will generally continue to work with the
+newer NVML releases; however, the newer function versions will not work with
+older NVML installs.
+
+By default these bindings only include the newest versions of the functions.
+Enable the `legacy-functions` feature if you require the ability to call older
+functions.
+
 #### License
 
 <sup>

--- a/nvml-wrapper-sys/gen_bindings.sh
+++ b/nvml-wrapper-sys/gen_bindings.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+
+bindgen --ctypes-prefix raw --no-doc-comments --no-layout-tests --raw-line '#![allow(non_upper_case_globals)]' \
+    --raw-line '#![allow(non_camel_case_types)]' --raw-line '#![allow(non_snake_case)]' \
+    --raw-line '#![allow(dead_code)]'  --raw-line 'use std::os::raw;' --rustfmt-bindings \
+    --dynamic-loading NvmlLib -o genned_bindings.rs nvml.h \
+    -- -DNVML_NO_UNVERSIONED_FUNC_DEFS # Define `NVML_NO_UNVERSIONED_FUNC_DEFS` so we get generated bindings for legacy functions
+
+# list of legacy function names to hide behind `#[cfg(feature = "legacy-functions")]`
+declare -a arr=(
+    "nvmlInit"
+    "nvmlDeviceGetCount"
+    "nvmlDeviceGetHandleByIndex"
+    "nvmlDeviceGetHandleByPciBusId"
+    "nvmlDeviceGetPciInfo"
+    "nvmlDeviceGetPciInfo_v2"
+    "nvmlDeviceGetNvLinkRemotePciInfo"
+    "nvmlDeviceGetGridLicensableFeatures"
+    "nvmlDeviceGetGridLicensableFeatures_v2"
+    "nvmlDeviceGetGridLicensableFeatures_v3"
+    "nvmlDeviceRemoveGpu"
+    "nvmlEventSetWait"
+    "nvmlDeviceGetAttributes"
+    "nvmlComputeInstanceGetInfo"
+    "nvmlDeviceGetComputeRunningProcesses_v2"
+    "nvmlDeviceGetComputeRunningProcesses"
+    "nvmlDeviceGetGraphicsRunningProcesses"
+    "nvmlDeviceGetGraphicsRunningProcesses_v2"
+    "nvmlDeviceGetMPSComputeRunningProcesses"
+    "nvmlDeviceGetMPSComputeRunningProcesses_v2"
+    "nvmlDeviceGetGpuInstancePossiblePlacements"
+    "nvmlVgpuInstanceGetLicenseInfo"
+)
+
+sed_regex="("
+
+# match struct field definitions
+for i in "${arr[@]}"
+do
+    sed_regex+="pub ${i}:|"
+done
+
+# match code to get symbols in constructor
+for i in "${arr[@]}"
+do
+    sed_regex+="let ${i} =|"
+done
+
+# match struct fields in constructor
+for i in "${arr[@]}"
+do
+    sed_regex+="${i},|"
+done
+
+# match method definitions
+for i in "${arr[@]}"
+do
+    sed_regex+="pub unsafe fn ${i}\(|"
+done
+
+# remove the trailing |
+sed_regex=${sed_regex%?}
+sed_regex+=").*"
+
+# Place `#[cfg(feature = "legacy-functions")]` in front of all lines related to legacy function support
+sed -E -i '/('\
+"$sed_regex"\
+').*/i #[cfg(feature = "legacy-functions")]' genned_bindings.rs
+
+# create the field_id module to improve structure of the bindings
+sed -i '/pub const NVML_FI_DEV_ECC_CURRENT:.*/i pub mod field_id {' genned_bindings.rs
+sed -i '/pub const NVML_FI_MAX:.*/a }' genned_bindings.rs
+
+# make the __library field public so we can access it from the wrapper
+sed -i 's/__library: ::libloading::Library,/pub __library: ::libloading::Library,/' genned_bindings.rs
+
+# final format after using sed on the bindings
+rustfmt genned_bindings.rs

--- a/nvml-wrapper-sys/src/bindings.rs
+++ b/nvml-wrapper-sys/src/bindings.rs
@@ -3196,6 +3196,171 @@ pub struct NvmlLib {
         ) -> nvmlReturn_t,
         ::libloading::Error,
     >,
+    #[cfg(feature = "legacy-functions")]
+    pub nvmlInit: Result<unsafe extern "C" fn() -> nvmlReturn_t, ::libloading::Error>,
+    #[cfg(feature = "legacy-functions")]
+    pub nvmlDeviceGetCount: Result<
+        unsafe extern "C" fn(deviceCount: *mut raw::c_uint) -> nvmlReturn_t,
+        ::libloading::Error,
+    >,
+    #[cfg(feature = "legacy-functions")]
+    pub nvmlDeviceGetHandleByIndex: Result<
+        unsafe extern "C" fn(index: raw::c_uint, device: *mut nvmlDevice_t) -> nvmlReturn_t,
+        ::libloading::Error,
+    >,
+    #[cfg(feature = "legacy-functions")]
+    pub nvmlDeviceGetHandleByPciBusId: Result<
+        unsafe extern "C" fn(
+            pciBusId: *const raw::c_char,
+            device: *mut nvmlDevice_t,
+        ) -> nvmlReturn_t,
+        ::libloading::Error,
+    >,
+    #[cfg(feature = "legacy-functions")]
+    pub nvmlDeviceGetPciInfo: Result<
+        unsafe extern "C" fn(device: nvmlDevice_t, pci: *mut nvmlPciInfo_t) -> nvmlReturn_t,
+        ::libloading::Error,
+    >,
+    #[cfg(feature = "legacy-functions")]
+    pub nvmlDeviceGetPciInfo_v2: Result<
+        unsafe extern "C" fn(device: nvmlDevice_t, pci: *mut nvmlPciInfo_t) -> nvmlReturn_t,
+        ::libloading::Error,
+    >,
+    #[cfg(feature = "legacy-functions")]
+    pub nvmlDeviceGetNvLinkRemotePciInfo: Result<
+        unsafe extern "C" fn(
+            device: nvmlDevice_t,
+            link: raw::c_uint,
+            pci: *mut nvmlPciInfo_t,
+        ) -> nvmlReturn_t,
+        ::libloading::Error,
+    >,
+    #[cfg(feature = "legacy-functions")]
+    pub nvmlDeviceGetGridLicensableFeatures: Result<
+        unsafe extern "C" fn(
+            device: nvmlDevice_t,
+            pGridLicensableFeatures: *mut nvmlGridLicensableFeatures_t,
+        ) -> nvmlReturn_t,
+        ::libloading::Error,
+    >,
+    #[cfg(feature = "legacy-functions")]
+    pub nvmlDeviceGetGridLicensableFeatures_v2: Result<
+        unsafe extern "C" fn(
+            device: nvmlDevice_t,
+            pGridLicensableFeatures: *mut nvmlGridLicensableFeatures_t,
+        ) -> nvmlReturn_t,
+        ::libloading::Error,
+    >,
+    #[cfg(feature = "legacy-functions")]
+    pub nvmlDeviceGetGridLicensableFeatures_v3: Result<
+        unsafe extern "C" fn(
+            device: nvmlDevice_t,
+            pGridLicensableFeatures: *mut nvmlGridLicensableFeatures_t,
+        ) -> nvmlReturn_t,
+        ::libloading::Error,
+    >,
+    #[cfg(feature = "legacy-functions")]
+    pub nvmlDeviceRemoveGpu: Result<
+        unsafe extern "C" fn(pciInfo: *mut nvmlPciInfo_t) -> nvmlReturn_t,
+        ::libloading::Error,
+    >,
+    #[cfg(feature = "legacy-functions")]
+    pub nvmlEventSetWait: Result<
+        unsafe extern "C" fn(
+            set: nvmlEventSet_t,
+            data: *mut nvmlEventData_t,
+            timeoutms: raw::c_uint,
+        ) -> nvmlReturn_t,
+        ::libloading::Error,
+    >,
+    #[cfg(feature = "legacy-functions")]
+    pub nvmlDeviceGetAttributes: Result<
+        unsafe extern "C" fn(
+            device: nvmlDevice_t,
+            attributes: *mut nvmlDeviceAttributes_t,
+        ) -> nvmlReturn_t,
+        ::libloading::Error,
+    >,
+    #[cfg(feature = "legacy-functions")]
+    pub nvmlComputeInstanceGetInfo: Result<
+        unsafe extern "C" fn(
+            computeInstance: nvmlComputeInstance_t,
+            info: *mut nvmlComputeInstanceInfo_t,
+        ) -> nvmlReturn_t,
+        ::libloading::Error,
+    >,
+    #[cfg(feature = "legacy-functions")]
+    pub nvmlDeviceGetComputeRunningProcesses: Result<
+        unsafe extern "C" fn(
+            device: nvmlDevice_t,
+            infoCount: *mut raw::c_uint,
+            infos: *mut nvmlProcessInfo_v1_t,
+        ) -> nvmlReturn_t,
+        ::libloading::Error,
+    >,
+    #[cfg(feature = "legacy-functions")]
+    pub nvmlDeviceGetComputeRunningProcesses_v2: Result<
+        unsafe extern "C" fn(
+            device: nvmlDevice_t,
+            infoCount: *mut raw::c_uint,
+            infos: *mut nvmlProcessInfo_v2_t,
+        ) -> nvmlReturn_t,
+        ::libloading::Error,
+    >,
+    #[cfg(feature = "legacy-functions")]
+    pub nvmlDeviceGetGraphicsRunningProcesses: Result<
+        unsafe extern "C" fn(
+            device: nvmlDevice_t,
+            infoCount: *mut raw::c_uint,
+            infos: *mut nvmlProcessInfo_v1_t,
+        ) -> nvmlReturn_t,
+        ::libloading::Error,
+    >,
+    #[cfg(feature = "legacy-functions")]
+    pub nvmlDeviceGetGraphicsRunningProcesses_v2: Result<
+        unsafe extern "C" fn(
+            device: nvmlDevice_t,
+            infoCount: *mut raw::c_uint,
+            infos: *mut nvmlProcessInfo_v2_t,
+        ) -> nvmlReturn_t,
+        ::libloading::Error,
+    >,
+    #[cfg(feature = "legacy-functions")]
+    pub nvmlDeviceGetMPSComputeRunningProcesses: Result<
+        unsafe extern "C" fn(
+            device: nvmlDevice_t,
+            infoCount: *mut raw::c_uint,
+            infos: *mut nvmlProcessInfo_v1_t,
+        ) -> nvmlReturn_t,
+        ::libloading::Error,
+    >,
+    #[cfg(feature = "legacy-functions")]
+    pub nvmlDeviceGetMPSComputeRunningProcesses_v2: Result<
+        unsafe extern "C" fn(
+            device: nvmlDevice_t,
+            infoCount: *mut raw::c_uint,
+            infos: *mut nvmlProcessInfo_v2_t,
+        ) -> nvmlReturn_t,
+        ::libloading::Error,
+    >,
+    #[cfg(feature = "legacy-functions")]
+    pub nvmlDeviceGetGpuInstancePossiblePlacements: Result<
+        unsafe extern "C" fn(
+            device: nvmlDevice_t,
+            profileId: raw::c_uint,
+            placements: *mut nvmlGpuInstancePlacement_t,
+            count: *mut raw::c_uint,
+        ) -> nvmlReturn_t,
+        ::libloading::Error,
+    >,
+    #[cfg(feature = "legacy-functions")]
+    pub nvmlVgpuInstanceGetLicenseInfo: Result<
+        unsafe extern "C" fn(
+            vgpuInstance: nvmlVgpuInstance_t,
+            licenseInfo: *mut nvmlVgpuLicenseInfo_t,
+        ) -> nvmlReturn_t,
+        ::libloading::Error,
+    >,
 }
 impl NvmlLib {
     pub unsafe fn new<P>(path: P) -> Result<Self, ::libloading::Error>
@@ -3863,6 +4028,80 @@ impl NvmlLib {
         let nvmlGpmQueryDeviceSupport = __library
             .get(b"nvmlGpmQueryDeviceSupport\0")
             .map(|sym| *sym);
+        #[cfg(feature = "legacy-functions")]
+        let nvmlInit = __library.get(b"nvmlInit\0").map(|sym| *sym);
+        #[cfg(feature = "legacy-functions")]
+        let nvmlDeviceGetCount = __library.get(b"nvmlDeviceGetCount\0").map(|sym| *sym);
+        #[cfg(feature = "legacy-functions")]
+        let nvmlDeviceGetHandleByIndex = __library
+            .get(b"nvmlDeviceGetHandleByIndex\0")
+            .map(|sym| *sym);
+        #[cfg(feature = "legacy-functions")]
+        let nvmlDeviceGetHandleByPciBusId = __library
+            .get(b"nvmlDeviceGetHandleByPciBusId\0")
+            .map(|sym| *sym);
+        #[cfg(feature = "legacy-functions")]
+        let nvmlDeviceGetPciInfo = __library.get(b"nvmlDeviceGetPciInfo\0").map(|sym| *sym);
+        #[cfg(feature = "legacy-functions")]
+        let nvmlDeviceGetPciInfo_v2 = __library.get(b"nvmlDeviceGetPciInfo_v2\0").map(|sym| *sym);
+        #[cfg(feature = "legacy-functions")]
+        let nvmlDeviceGetNvLinkRemotePciInfo = __library
+            .get(b"nvmlDeviceGetNvLinkRemotePciInfo\0")
+            .map(|sym| *sym);
+        #[cfg(feature = "legacy-functions")]
+        let nvmlDeviceGetGridLicensableFeatures = __library
+            .get(b"nvmlDeviceGetGridLicensableFeatures\0")
+            .map(|sym| *sym);
+        #[cfg(feature = "legacy-functions")]
+        let nvmlDeviceGetGridLicensableFeatures_v2 = __library
+            .get(b"nvmlDeviceGetGridLicensableFeatures_v2\0")
+            .map(|sym| *sym);
+        #[cfg(feature = "legacy-functions")]
+        let nvmlDeviceGetGridLicensableFeatures_v3 = __library
+            .get(b"nvmlDeviceGetGridLicensableFeatures_v3\0")
+            .map(|sym| *sym);
+        #[cfg(feature = "legacy-functions")]
+        let nvmlDeviceRemoveGpu = __library.get(b"nvmlDeviceRemoveGpu\0").map(|sym| *sym);
+        #[cfg(feature = "legacy-functions")]
+        let nvmlEventSetWait = __library.get(b"nvmlEventSetWait\0").map(|sym| *sym);
+        #[cfg(feature = "legacy-functions")]
+        let nvmlDeviceGetAttributes = __library.get(b"nvmlDeviceGetAttributes\0").map(|sym| *sym);
+        #[cfg(feature = "legacy-functions")]
+        let nvmlComputeInstanceGetInfo = __library
+            .get(b"nvmlComputeInstanceGetInfo\0")
+            .map(|sym| *sym);
+        #[cfg(feature = "legacy-functions")]
+        let nvmlDeviceGetComputeRunningProcesses = __library
+            .get(b"nvmlDeviceGetComputeRunningProcesses\0")
+            .map(|sym| *sym);
+        #[cfg(feature = "legacy-functions")]
+        let nvmlDeviceGetComputeRunningProcesses_v2 = __library
+            .get(b"nvmlDeviceGetComputeRunningProcesses_v2\0")
+            .map(|sym| *sym);
+        #[cfg(feature = "legacy-functions")]
+        let nvmlDeviceGetGraphicsRunningProcesses = __library
+            .get(b"nvmlDeviceGetGraphicsRunningProcesses\0")
+            .map(|sym| *sym);
+        #[cfg(feature = "legacy-functions")]
+        let nvmlDeviceGetGraphicsRunningProcesses_v2 = __library
+            .get(b"nvmlDeviceGetGraphicsRunningProcesses_v2\0")
+            .map(|sym| *sym);
+        #[cfg(feature = "legacy-functions")]
+        let nvmlDeviceGetMPSComputeRunningProcesses = __library
+            .get(b"nvmlDeviceGetMPSComputeRunningProcesses\0")
+            .map(|sym| *sym);
+        #[cfg(feature = "legacy-functions")]
+        let nvmlDeviceGetMPSComputeRunningProcesses_v2 = __library
+            .get(b"nvmlDeviceGetMPSComputeRunningProcesses_v2\0")
+            .map(|sym| *sym);
+        #[cfg(feature = "legacy-functions")]
+        let nvmlDeviceGetGpuInstancePossiblePlacements = __library
+            .get(b"nvmlDeviceGetGpuInstancePossiblePlacements\0")
+            .map(|sym| *sym);
+        #[cfg(feature = "legacy-functions")]
+        let nvmlVgpuInstanceGetLicenseInfo = __library
+            .get(b"nvmlVgpuInstanceGetLicenseInfo\0")
+            .map(|sym| *sym);
         Ok(NvmlLib {
             __library,
             nvmlInit_v2,
@@ -4138,6 +4377,50 @@ impl NvmlLib {
             nvmlGpmSampleAlloc,
             nvmlGpmSampleGet,
             nvmlGpmQueryDeviceSupport,
+            #[cfg(feature = "legacy-functions")]
+            nvmlInit,
+            #[cfg(feature = "legacy-functions")]
+            nvmlDeviceGetCount,
+            #[cfg(feature = "legacy-functions")]
+            nvmlDeviceGetHandleByIndex,
+            #[cfg(feature = "legacy-functions")]
+            nvmlDeviceGetHandleByPciBusId,
+            #[cfg(feature = "legacy-functions")]
+            nvmlDeviceGetPciInfo,
+            #[cfg(feature = "legacy-functions")]
+            nvmlDeviceGetPciInfo_v2,
+            #[cfg(feature = "legacy-functions")]
+            nvmlDeviceGetNvLinkRemotePciInfo,
+            #[cfg(feature = "legacy-functions")]
+            nvmlDeviceGetGridLicensableFeatures,
+            #[cfg(feature = "legacy-functions")]
+            nvmlDeviceGetGridLicensableFeatures_v2,
+            #[cfg(feature = "legacy-functions")]
+            nvmlDeviceGetGridLicensableFeatures_v3,
+            #[cfg(feature = "legacy-functions")]
+            nvmlDeviceRemoveGpu,
+            #[cfg(feature = "legacy-functions")]
+            nvmlEventSetWait,
+            #[cfg(feature = "legacy-functions")]
+            nvmlDeviceGetAttributes,
+            #[cfg(feature = "legacy-functions")]
+            nvmlComputeInstanceGetInfo,
+            #[cfg(feature = "legacy-functions")]
+            nvmlDeviceGetComputeRunningProcesses,
+            #[cfg(feature = "legacy-functions")]
+            nvmlDeviceGetComputeRunningProcesses_v2,
+            #[cfg(feature = "legacy-functions")]
+            nvmlDeviceGetGraphicsRunningProcesses,
+            #[cfg(feature = "legacy-functions")]
+            nvmlDeviceGetGraphicsRunningProcesses_v2,
+            #[cfg(feature = "legacy-functions")]
+            nvmlDeviceGetMPSComputeRunningProcesses,
+            #[cfg(feature = "legacy-functions")]
+            nvmlDeviceGetMPSComputeRunningProcesses_v2,
+            #[cfg(feature = "legacy-functions")]
+            nvmlDeviceGetGpuInstancePossiblePlacements,
+            #[cfg(feature = "legacy-functions")]
+            nvmlVgpuInstanceGetLicenseInfo,
         })
     }
     pub unsafe fn nvmlInit_v2(&self) -> nvmlReturn_t {
@@ -7031,5 +7314,245 @@ impl NvmlLib {
             .nvmlGpmQueryDeviceSupport
             .as_ref()
             .expect("Expected function, got error."))(device, gpmSupport)
+    }
+    #[cfg(feature = "legacy-functions")]
+    pub unsafe fn nvmlInit(&self) -> nvmlReturn_t {
+        (self
+            .nvmlInit
+            .as_ref()
+            .expect("Expected function, got error."))()
+    }
+    #[cfg(feature = "legacy-functions")]
+    pub unsafe fn nvmlDeviceGetCount(&self, deviceCount: *mut raw::c_uint) -> nvmlReturn_t {
+        (self
+            .nvmlDeviceGetCount
+            .as_ref()
+            .expect("Expected function, got error."))(deviceCount)
+    }
+    #[cfg(feature = "legacy-functions")]
+    pub unsafe fn nvmlDeviceGetHandleByIndex(
+        &self,
+        index: raw::c_uint,
+        device: *mut nvmlDevice_t,
+    ) -> nvmlReturn_t {
+        (self
+            .nvmlDeviceGetHandleByIndex
+            .as_ref()
+            .expect("Expected function, got error."))(index, device)
+    }
+    #[cfg(feature = "legacy-functions")]
+    pub unsafe fn nvmlDeviceGetHandleByPciBusId(
+        &self,
+        pciBusId: *const raw::c_char,
+        device: *mut nvmlDevice_t,
+    ) -> nvmlReturn_t {
+        (self
+            .nvmlDeviceGetHandleByPciBusId
+            .as_ref()
+            .expect("Expected function, got error."))(pciBusId, device)
+    }
+    #[cfg(feature = "legacy-functions")]
+    pub unsafe fn nvmlDeviceGetPciInfo(
+        &self,
+        device: nvmlDevice_t,
+        pci: *mut nvmlPciInfo_t,
+    ) -> nvmlReturn_t {
+        (self
+            .nvmlDeviceGetPciInfo
+            .as_ref()
+            .expect("Expected function, got error."))(device, pci)
+    }
+    #[cfg(feature = "legacy-functions")]
+    pub unsafe fn nvmlDeviceGetPciInfo_v2(
+        &self,
+        device: nvmlDevice_t,
+        pci: *mut nvmlPciInfo_t,
+    ) -> nvmlReturn_t {
+        (self
+            .nvmlDeviceGetPciInfo_v2
+            .as_ref()
+            .expect("Expected function, got error."))(device, pci)
+    }
+    #[cfg(feature = "legacy-functions")]
+    pub unsafe fn nvmlDeviceGetNvLinkRemotePciInfo(
+        &self,
+        device: nvmlDevice_t,
+        link: raw::c_uint,
+        pci: *mut nvmlPciInfo_t,
+    ) -> nvmlReturn_t {
+        (self
+            .nvmlDeviceGetNvLinkRemotePciInfo
+            .as_ref()
+            .expect("Expected function, got error."))(device, link, pci)
+    }
+    #[cfg(feature = "legacy-functions")]
+    pub unsafe fn nvmlDeviceGetGridLicensableFeatures(
+        &self,
+        device: nvmlDevice_t,
+        pGridLicensableFeatures: *mut nvmlGridLicensableFeatures_t,
+    ) -> nvmlReturn_t {
+        (self
+            .nvmlDeviceGetGridLicensableFeatures
+            .as_ref()
+            .expect("Expected function, got error."))(device, pGridLicensableFeatures)
+    }
+    #[cfg(feature = "legacy-functions")]
+    pub unsafe fn nvmlDeviceGetGridLicensableFeatures_v2(
+        &self,
+        device: nvmlDevice_t,
+        pGridLicensableFeatures: *mut nvmlGridLicensableFeatures_t,
+    ) -> nvmlReturn_t {
+        (self
+            .nvmlDeviceGetGridLicensableFeatures_v2
+            .as_ref()
+            .expect("Expected function, got error."))(device, pGridLicensableFeatures)
+    }
+    #[cfg(feature = "legacy-functions")]
+    pub unsafe fn nvmlDeviceGetGridLicensableFeatures_v3(
+        &self,
+        device: nvmlDevice_t,
+        pGridLicensableFeatures: *mut nvmlGridLicensableFeatures_t,
+    ) -> nvmlReturn_t {
+        (self
+            .nvmlDeviceGetGridLicensableFeatures_v3
+            .as_ref()
+            .expect("Expected function, got error."))(device, pGridLicensableFeatures)
+    }
+    #[cfg(feature = "legacy-functions")]
+    pub unsafe fn nvmlDeviceRemoveGpu(&self, pciInfo: *mut nvmlPciInfo_t) -> nvmlReturn_t {
+        (self
+            .nvmlDeviceRemoveGpu
+            .as_ref()
+            .expect("Expected function, got error."))(pciInfo)
+    }
+    #[cfg(feature = "legacy-functions")]
+    pub unsafe fn nvmlEventSetWait(
+        &self,
+        set: nvmlEventSet_t,
+        data: *mut nvmlEventData_t,
+        timeoutms: raw::c_uint,
+    ) -> nvmlReturn_t {
+        (self
+            .nvmlEventSetWait
+            .as_ref()
+            .expect("Expected function, got error."))(set, data, timeoutms)
+    }
+    #[cfg(feature = "legacy-functions")]
+    pub unsafe fn nvmlDeviceGetAttributes(
+        &self,
+        device: nvmlDevice_t,
+        attributes: *mut nvmlDeviceAttributes_t,
+    ) -> nvmlReturn_t {
+        (self
+            .nvmlDeviceGetAttributes
+            .as_ref()
+            .expect("Expected function, got error."))(device, attributes)
+    }
+    #[cfg(feature = "legacy-functions")]
+    pub unsafe fn nvmlComputeInstanceGetInfo(
+        &self,
+        computeInstance: nvmlComputeInstance_t,
+        info: *mut nvmlComputeInstanceInfo_t,
+    ) -> nvmlReturn_t {
+        (self
+            .nvmlComputeInstanceGetInfo
+            .as_ref()
+            .expect("Expected function, got error."))(computeInstance, info)
+    }
+    #[cfg(feature = "legacy-functions")]
+    pub unsafe fn nvmlDeviceGetComputeRunningProcesses(
+        &self,
+        device: nvmlDevice_t,
+        infoCount: *mut raw::c_uint,
+        infos: *mut nvmlProcessInfo_v1_t,
+    ) -> nvmlReturn_t {
+        (self
+            .nvmlDeviceGetComputeRunningProcesses
+            .as_ref()
+            .expect("Expected function, got error."))(device, infoCount, infos)
+    }
+    #[cfg(feature = "legacy-functions")]
+    pub unsafe fn nvmlDeviceGetComputeRunningProcesses_v2(
+        &self,
+        device: nvmlDevice_t,
+        infoCount: *mut raw::c_uint,
+        infos: *mut nvmlProcessInfo_v2_t,
+    ) -> nvmlReturn_t {
+        (self
+            .nvmlDeviceGetComputeRunningProcesses_v2
+            .as_ref()
+            .expect("Expected function, got error."))(device, infoCount, infos)
+    }
+    #[cfg(feature = "legacy-functions")]
+    pub unsafe fn nvmlDeviceGetGraphicsRunningProcesses(
+        &self,
+        device: nvmlDevice_t,
+        infoCount: *mut raw::c_uint,
+        infos: *mut nvmlProcessInfo_v1_t,
+    ) -> nvmlReturn_t {
+        (self
+            .nvmlDeviceGetGraphicsRunningProcesses
+            .as_ref()
+            .expect("Expected function, got error."))(device, infoCount, infos)
+    }
+    #[cfg(feature = "legacy-functions")]
+    pub unsafe fn nvmlDeviceGetGraphicsRunningProcesses_v2(
+        &self,
+        device: nvmlDevice_t,
+        infoCount: *mut raw::c_uint,
+        infos: *mut nvmlProcessInfo_v2_t,
+    ) -> nvmlReturn_t {
+        (self
+            .nvmlDeviceGetGraphicsRunningProcesses_v2
+            .as_ref()
+            .expect("Expected function, got error."))(device, infoCount, infos)
+    }
+    #[cfg(feature = "legacy-functions")]
+    pub unsafe fn nvmlDeviceGetMPSComputeRunningProcesses(
+        &self,
+        device: nvmlDevice_t,
+        infoCount: *mut raw::c_uint,
+        infos: *mut nvmlProcessInfo_v1_t,
+    ) -> nvmlReturn_t {
+        (self
+            .nvmlDeviceGetMPSComputeRunningProcesses
+            .as_ref()
+            .expect("Expected function, got error."))(device, infoCount, infos)
+    }
+    #[cfg(feature = "legacy-functions")]
+    pub unsafe fn nvmlDeviceGetMPSComputeRunningProcesses_v2(
+        &self,
+        device: nvmlDevice_t,
+        infoCount: *mut raw::c_uint,
+        infos: *mut nvmlProcessInfo_v2_t,
+    ) -> nvmlReturn_t {
+        (self
+            .nvmlDeviceGetMPSComputeRunningProcesses_v2
+            .as_ref()
+            .expect("Expected function, got error."))(device, infoCount, infos)
+    }
+    #[cfg(feature = "legacy-functions")]
+    pub unsafe fn nvmlDeviceGetGpuInstancePossiblePlacements(
+        &self,
+        device: nvmlDevice_t,
+        profileId: raw::c_uint,
+        placements: *mut nvmlGpuInstancePlacement_t,
+        count: *mut raw::c_uint,
+    ) -> nvmlReturn_t {
+        (self
+            .nvmlDeviceGetGpuInstancePossiblePlacements
+            .as_ref()
+            .expect("Expected function, got error."))(device, profileId, placements, count)
+    }
+    #[cfg(feature = "legacy-functions")]
+    pub unsafe fn nvmlVgpuInstanceGetLicenseInfo(
+        &self,
+        vgpuInstance: nvmlVgpuInstance_t,
+        licenseInfo: *mut nvmlVgpuLicenseInfo_t,
+    ) -> nvmlReturn_t {
+        (self
+            .nvmlVgpuInstanceGetLicenseInfo
+            .as_ref()
+            .expect("Expected function, got error."))(vgpuInstance, licenseInfo)
     }
 }

--- a/nvml-wrapper-sys/src/lib.rs
+++ b/nvml-wrapper-sys/src/lib.rs
@@ -1,7 +1,6 @@
 /*!
-Rust bindings for the
-[NVIDIA Management Library][nvml] (NVML), a C-based programmatic interface for monitoring
-and managing various states within NVIDIA (primarily Tesla) GPUs.
+Rust bindings for the [NVIDIA Management Library][nvml] (NVML), a C-based programmatic
+interface for monitoring and managing various states within NVIDIA GPUs.
 
 It is intended to be a platform for building 3rd-party applications, and is also the
 underlying library for NVIDIA's nvidia-smi tool.
@@ -35,6 +34,25 @@ These bindings were generated for NVML version 11. Each new version of NVML is
 guaranteed to be backwards-compatible according to NVIDIA, so these bindings
 should be useful regardless of NVML version bumps.
 
+### Legacy Functions
+
+Sometimes there will be function-level API version bumps in new NVML releases.
+For example:
+
+```text
+nvmlDeviceGetComputeRunningProcesses
+nvmlDeviceGetComputeRunningProcesses_v2
+nvmlDeviceGetComputeRunningProcesses_v3
+```
+
+The older versions of the functions will generally continue to work with the
+newer NVML releases; however, the newer function versions will not work with
+older NVML installs.
+
+By default these bindings only include the newest versions of the functions.
+Enable the `legacy-functions` feature if you require the ability to call older
+functions.
+
 [nvml]: https://developer.nvidia.com/nvidia-management-library-nvml
 [nvml-wrapper]: https://github.com/Cldfire/nvml-wrapper
 [bindgen]: https://github.com/rust-lang/rust-bindgen
@@ -45,7 +63,7 @@ should be useful regardless of NVML version bumps.
 #![allow(clippy::missing_safety_doc)]
 #![allow(clippy::redundant_static_lifetimes)]
 
-// Generate bindings: bindgen --ctypes-prefix raw --no-doc-comments --no-layout-tests --raw-line '#![allow(non_upper_case_globals)]' --raw-line '#![allow(non_camel_case_types)]' --raw-line '#![allow(non_snake_case)]' --raw-line '#![allow(dead_code)]'  --raw-line 'use std::os::raw;' --rustfmt-bindings --dynamic-loading NvmlLib -o genned_bindings.rs nvml.h
+// Generate bindings: ./gen_bindings.sh
 //
 // We avoid generating layout tests because they cause a large number of
 // warnings and according to commentary are not useful. See

--- a/nvml-wrapper/Cargo.toml
+++ b/nvml-wrapper/Cargo.toml
@@ -13,6 +13,10 @@ rust-version = "1.51.0"
 keywords = ["nvidia", "gpu", "managment", "monitoring", "hardware"]
 categories = ["api-bindings", "hardware-support"]
 
+[features]
+default = []
+legacy-functions = ["nvml-wrapper-sys/legacy-functions"]
+
 [dependencies]
 thiserror = "1.0"
 bitflags = "1.3"

--- a/nvml-wrapper/src/lib.rs
+++ b/nvml-wrapper/src/lib.rs
@@ -3,10 +3,8 @@ A safe and ergonomic Rust wrapper for the [NVIDIA Management Library][nvml] (NVM
 a C-based programmatic interface for monitoring and managing various states within
 NVIDIA GPUs.
 
-```
+```rust
 use nvml_wrapper::Nvml;
-# use nvml_wrapper::error::*;
-# fn test() -> Result<(), NvmlError> {
 
 let nvml = Nvml::init()?;
 // Get the first `Device` (GPU) in the system
@@ -19,8 +17,6 @@ let encoder_util = device.encoder_utilization()?; // Currently 0 on my system; N
 let memory_info = device.memory_info()?; // Currently 1.63/6.37 GB used on my system
 
 // ... and there's a whole lot more you can do. Most everything in NVML is wrapped and ready to go
-# Ok(())
-# }
 ```
 
 NVML is intended to be a platform for building 3rd-party applications, and is
@@ -55,6 +51,25 @@ This wrapper is being developed against and currently supports NVML version
 11. Each new version of NVML is guaranteed to be backwards-compatible according
 to NVIDIA, so this wrapper should continue to work without issue regardless of
 NVML version bumps.
+
+### Legacy Functions
+
+Sometimes there will be function-level API version bumps in new NVML releases.
+For example:
+
+```text
+nvmlDeviceGetComputeRunningProcesses
+nvmlDeviceGetComputeRunningProcesses_v2
+nvmlDeviceGetComputeRunningProcesses_v3
+```
+
+The older versions of the functions will generally continue to work with the
+newer NVML releases; however, the newer function versions will not work with
+older NVML installs.
+
+By default this wrapper only provides access to the newest function versions.
+Enable the `legacy-functions` feature if you require the ability to call older
+functions.
 
 ## MSRV
 

--- a/nvml-wrapper/src/lib.rs
+++ b/nvml-wrapper/src/lib.rs
@@ -3,8 +3,10 @@ A safe and ergonomic Rust wrapper for the [NVIDIA Management Library][nvml] (NVM
 a C-based programmatic interface for monitoring and managing various states within
 NVIDIA GPUs.
 
-```rust
+```
 use nvml_wrapper::Nvml;
+# use nvml_wrapper::error::*;
+# fn test() -> Result<(), NvmlError> {
 
 let nvml = Nvml::init()?;
 // Get the first `Device` (GPU) in the system
@@ -17,6 +19,8 @@ let encoder_util = device.encoder_utilization()?; // Currently 0 on my system; N
 let memory_info = device.memory_info()?; // Currently 1.63/6.37 GB used on my system
 
 // ... and there's a whole lot more you can do. Most everything in NVML is wrapped and ready to go
+# Ok(())
+# }
 ```
 
 NVML is intended to be a platform for building 3rd-party applications, and is

--- a/nvml-wrapper/src/struct_wrappers/device.rs
+++ b/nvml-wrapper/src/struct_wrappers/device.rs
@@ -261,6 +261,23 @@ impl From<nvmlProcessInfo_t> for ProcessInfo {
     }
 }
 
+#[cfg(feature = "legacy-functions")]
+impl From<nvmlProcessInfo_v2_t> for ProcessInfo {
+    fn from(struct_: nvmlProcessInfo_v2_t) -> Self {
+        // These versions of the struct are exactly the same, so we can rely on
+        // the above `From` impl and just treat this struct as the unversioned
+        // one.
+        let unversioned_struct = nvmlProcessInfo_t {
+            pid: struct_.pid,
+            usedGpuMemory: struct_.usedGpuMemory,
+            gpuInstanceId: struct_.gpuInstanceId,
+            computeInstanceId: struct_.computeInstanceId,
+        };
+
+        Self::from(unversioned_struct)
+    }
+}
+
 /// Detailed ECC error counts for a device.
 // Checked against local
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]


### PR DESCRIPTION
This makes it possible to enable a feature and then have access to older versions of functions in both the wrapper and the bindings.

Initially adding wrappers for the v2 versions of running compute / graphics processes.

Closes #33.