### PR TITLE
(minor change) Fix documentation of total_energy_consumption

### DIFF
--- a/nvml-wrapper/src/device.rs
+++ b/nvml-wrapper/src/device.rs
@@ -2416,7 +2416,7 @@ impl<'nvml> Device<'nvml> {
 
     # Device Support
 
-    Supports Pascal and newer fully supported devices.
+    Supports Volta and newer fully supported devices.
     */
     #[doc(alias = "nvmlDeviceGetTotalEnergyConsumption")]
     pub fn total_energy_consumption(&self) -> Result<u64, NvmlError> {


### PR DESCRIPTION
I was surprised by the `NotSupported` errors I got when calling `total_energy_consumption` on a Pascal GPU. It turns out that [Nvidia's documentation reads](https://docs.nvidia.com/deploy/nvml-api/group__nvmlDeviceQueries.html) "Supports Volta and newer" instead of "Pascal and newer".