### PR TITLE
samples: Only return samples that are actually valid.

### DIFF
--- a/nvml-wrapper/src/device.rs
+++ b/nvml-wrapper/src/device.rs
@@ -2606,24 +2606,26 @@ impl<'nvml> Device<'nvml> {
 
         unsafe {
             let mut val_type: nvmlValueType_t = mem::zeroed();
-            let mut count = match self.samples_count(&sample_type, timestamp)? {
+            let count = match self.samples_count(&sample_type, timestamp)? {
                 0 => return Ok(vec![]),
                 value => value,
             };
             let mut samples: Vec<nvmlSample_t> = vec![mem::zeroed(); count as usize];
+            let mut new_count = count;
 
             nvml_try(sym(
                 self.device,
                 sample_type.as_c(),
                 timestamp,
                 &mut val_type,
-                &mut count,
+                &mut new_count,
                 samples.as_mut_ptr(),
             ))?;
 
             let val_type_rust = SampleValueType::try_from(val_type)?;
             Ok(samples
                 .into_iter()
+                .take(new_count as usize)
                 .map(|s| Sample::from_tag_and_struct(&val_type_rust, s))
                 .collect())
         }


### PR DESCRIPTION
The number of samples returned can be smaller than the number initially returned by `samples_count`. Account for this by only returning as many as are actually returned according to the second call to `nvmlDeviceGetSamples` .