### PR TITLE
device: fix attestation report size

### DIFF
--- a/nvml-wrapper/src/device.rs
+++ b/nvml-wrapper/src/device.rs
@@ -1058,8 +1058,11 @@ impl<'nvml> Device<'nvml> {
             Ok(ConfidentialComputeGpuCertificate {
                 cert_chain_size: certificate_chain.certChainSize,
                 attestation_cert_chain_size: certificate_chain.attestationCertChainSize,
-                cert_chain: certificate_chain.certChain.to_vec(),
-                attestation_cert_chain: certificate_chain.attestationCertChain.to_vec(),
+                cert_chain: certificate_chain.certChain[..certificate_chain.certChainSize as usize]
+                    .to_vec(),
+                attestation_cert_chain: certificate_chain.attestationCertChain
+                    [..certificate_chain.attestationCertChainSize as usize]
+                    .to_vec(),
             })
         }
     }


### PR DESCRIPTION
Currently we do not account for the size of the attestation reports when moving them from the C struct to the Rust struct. This results in many zeros being included at the end of the report.

Since the size of each report is provided, use this to include only the bytes which contain the report.

Also, do the same thing for the cert chains, although the cert chain format is a little more resilient to trailing characters.

cc @jorgeantonio21 