### PR TITLE
Fix spelling mistake of occurred

### DIFF
--- a/nvml-wrapper/src/device.rs
+++ b/nvml-wrapper/src/device.rs
@@ -5786,7 +5786,7 @@ impl<'nvml> Device<'nvml> {
     this `Device`.
 
     **Unfortunately, due to the way `error-chain` works, there is no way to
-    return the set if it is still valid after an error has occured with the
+    return the set if it is still valid after an error has occurred with the
     register call.** The set that you passed in will be freed if any error
     occurs and will not be returned to you. This is not desired behavior
     and I will fix it as soon as it is possible to do so.

--- a/nvml-wrapper/src/error.rs
+++ b/nvml-wrapper/src/error.rs
@@ -161,7 +161,7 @@ pub enum NvmlError {
     )]
     VgpuEccNotSupported,
 
-    #[error("an internal driver error occured")]
+    #[error("an internal driver error occurred")]
     Unknown,
 }
 


### PR DESCRIPTION
Fix the spelling mistake of `occurred`.