### PR TITLE
add method for getting the vGPU type id

### DIFF
--- a/nvml-wrapper/src/vgpu.rs
+++ b/nvml-wrapper/src/vgpu.rs
@@ -33,6 +33,11 @@ impl<'dev> VgpuType<'dev> {
         self.device
     }
 
+    /// Get the underlying vGPU type id.
+    pub fn id(&self) -> nvmlVgpuTypeId_t {
+        self.id
+    }
+
     /// Retrieve the class of the vGPU type.
     ///
     /// # Errors


### PR DESCRIPTION
This is useful for example on linux, where this id is the same as the one that needs to be written into sysfs for creating a vGPU instance.