### PR TITLE
Add changelog header for v0.12.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This file describes the changes / additions / fixes between wrapper releases, tr
 
 ## [Unreleased]
 
+## [0.12.0] (released 2026-02-11)
 ### Added
 
 * Add idiomatic abstraction for vGPU type information (#68)


### PR DESCRIPTION
We have the changelog contents but not the header. This fixes that.