### PR TITLE
feat: support power-mizer get/set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This file describes the changes / additions / fixes between wrapper releases, tr
 
 ## [Unreleased]
 
+### Added
+
+* `Device::power_mizer_mode()` and `Device::set_power_mizer_mode()` for NVML v580 PowerMizer mode support
+
 ## [0.12.1] (released 2026-03-27)
 
 ### Fixed

--- a/nvml-wrapper/src/bitmasks/device.rs
+++ b/nvml-wrapper/src/bitmasks/device.rs
@@ -74,6 +74,22 @@ bitflags! {
 }
 
 bitflags! {
+    /// Flags specifying the PowerMizer modes supported by a GPU.
+    #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+    #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
+    pub struct PowerMizerModes: u32 {
+        /// Adjust GPU clocks based on GPU utilization.
+        const ADAPTIVE = 1 << NVML_POWER_MIZER_MODE_ADAPTIVE;
+        /// Raise GPU clocks to favor maximum performance, within thermal and other constraints.
+        const PREFER_MAXIMUM_PERFORMANCE = 1 << NVML_POWER_MIZER_MODE_PREFER_MAXIMUM_PERFORMANCE;
+        /// Let the driver choose the performance policy.
+        const AUTO = 1 << NVML_POWER_MIZER_MODE_AUTO;
+        /// Lock to GPU base clocks.
+        const PREFER_CONSISTENT_PERFORMANCE = 1 << NVML_POWER_MIZER_MODE_PREFER_CONSISTENT_PERFORMANCE;
+    }
+}
+
+bitflags! {
     /// Flags that specify info about a frame capture session
     #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
     #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]

--- a/nvml-wrapper/src/device.rs
+++ b/nvml-wrapper/src/device.rs
@@ -4,7 +4,7 @@ use crate::GpmSample;
 use crate::NvLink;
 use crate::Nvml;
 
-use crate::bitmasks::device::ThrottleReasons;
+use crate::bitmasks::device::{PowerMizerModes, ThrottleReasons};
 #[cfg(target_os = "linux")]
 use crate::bitmasks::event::EventTypes;
 #[cfg(target_os = "windows")]
@@ -14,7 +14,7 @@ use crate::enum_wrappers::{bool_from_state, device::*, state_from_bool};
 
 use crate::enums::device::{
     BusType, DeviceArchitecture, FanControlPolicy, GpuLockedClocksSetting, PcieLinkMaxSpeed,
-    PowerSource,
+    PowerMizerMode, PowerSource,
 };
 use crate::error::nvml_try_count;
 #[cfg(target_os = "linux")]
@@ -3296,6 +3296,41 @@ impl<'nvml> Device<'nvml> {
         }
     }
 
+    /**
+    Gets the current and supported PowerMizer modes for this `Device`.
+
+    PowerMizer mode provides a hint to the driver for managing GPU performance.
+
+    # Errors
+
+    * `Uninitialized`, if the library has not been successfully initialized
+    * `InvalidArg`, if this `Device` is invalid
+    * `NotSupported`, if this `Device` does not support PowerMizer mode readings
+    * `GpuLost`, if this `Device` has fallen off the bus or is otherwise inaccessible
+    * `UnexpectedVariant`, if NVML returns an unknown current PowerMizer mode
+    * `Unknown`, on any unexpected error
+
+    # Device Support
+
+    Supports Maxwell or newer fully supported devices.
+    */
+    #[doc(alias = "nvmlDeviceGetPowerMizerMode_v1")]
+    pub fn power_mizer_mode(&self) -> Result<PowerMizerModeInfo, NvmlError> {
+        let sym = nvml_sym(self.nvml.lib.nvmlDeviceGetPowerMizerMode_v1.as_ref())?;
+
+        unsafe {
+            let mut power_mizer_mode: nvmlDevicePowerMizerModes_v1_t = mem::zeroed();
+            nvml_try(sym(self.device, &mut power_mizer_mode))?;
+
+            Ok(PowerMizerModeInfo {
+                current: PowerMizerMode::try_from(power_mizer_mode.currentMode)?,
+                supported: PowerMizerModes::from_bits_truncate(
+                    power_mizer_mode.supportedPowerMizerModes,
+                ),
+            })
+        }
+    }
+
     /// Not documenting this because it's deprecated. Read NVIDIA's docs if you
     /// must use it.
     // Tested
@@ -5601,6 +5636,39 @@ impl<'nvml> Device<'nvml> {
     }
 
     /**
+    Sets the PowerMizer mode for this `Device`.
+
+    PowerMizer mode provides a hint to the driver for managing GPU performance.
+    See `.power_mizer_mode()` to check supported modes.
+
+    # Errors
+
+    * `Uninitialized`, if the library has not been successfully initialized
+    * `InvalidArg`, if this `Device` is invalid or `mode` is invalid
+    * `NotSupported`, if this `Device` does not support PowerMizer mode changes
+    * `GpuLost`, if this `Device` has fallen off the bus or is otherwise inaccessible
+    * `Unknown`, on any unexpected error
+
+    # Device Support
+
+    Supports Maxwell or newer fully supported devices.
+    */
+    #[doc(alias = "nvmlDeviceSetPowerMizerMode_v1")]
+    pub fn set_power_mizer_mode(&mut self, mode: PowerMizerMode) -> Result<(), NvmlError> {
+        let sym = nvml_sym(self.nvml.lib.nvmlDeviceSetPowerMizerMode_v1.as_ref())?;
+
+        unsafe {
+            let mut power_mizer_mode = nvmlDevicePowerMizerModes_v1_t {
+                currentMode: mem::zeroed(),
+                mode: mode.as_c(),
+                supportedPowerMizerModes: mem::zeroed(),
+            };
+
+            nvml_try(sym(self.device, &mut power_mizer_mode))
+        }
+    }
+
+    /**
     Retrieve min, max and current clock offset of some clock domain for a given PState
 
     # Errors
@@ -6786,7 +6854,7 @@ mod test {
     #[cfg(target_os = "windows")]
     use crate::bitmasks::Behavior;
     use crate::enum_wrappers::device::*;
-    use crate::enums::device::GpuLockedClocksSetting;
+    use crate::enums::device::{GpuLockedClocksSetting, PowerMizerMode};
     use crate::error::*;
     use crate::structs::device::FieldId;
     use crate::sys_exports::field_id::*;
@@ -7333,6 +7401,13 @@ mod test {
         test_with_device(3, &nvml, |device| {
             device.power_management_limit_constraints()
         })
+    }
+
+    #[test]
+    #[ignore = "requires a v580+ driver and supported device"]
+    fn power_mizer_mode() {
+        let nvml = nvml();
+        test_with_device(3, &nvml, |device| device.power_mizer_mode())
     }
 
     #[test]
@@ -8024,6 +8099,17 @@ mod test {
         device
             .set_power_management_limit(250000)
             .expect("set to true")
+    }
+
+    // This modifies device state, so we don't want to actually run the test
+    #[allow(dead_code)]
+    fn set_power_mizer_mode() {
+        let nvml = nvml();
+        let mut device = device(&nvml);
+
+        device
+            .set_power_mizer_mode(PowerMizerMode::Auto)
+            .expect("set to auto")
     }
 
     // This modifies device state, so we don't want to actually run the test

--- a/nvml-wrapper/src/enums/device.rs
+++ b/nvml-wrapper/src/enums/device.rs
@@ -201,6 +201,52 @@ impl TryFrom<nvmlPowerSource_t> for PowerSource {
     }
 }
 
+/// PowerMizer mode preference for GPU performance management.
+// TODO: technically this is an "enum wrapper" but the type on the C side isn't
+// an enum
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub enum PowerMizerMode {
+    /// Adjust GPU clocks based on GPU utilization.
+    Adaptive,
+    /// Raise GPU clocks to favor maximum performance, within thermal and other constraints.
+    PreferMaximumPerformance,
+    /// Let the driver choose the performance policy.
+    Auto,
+    /// Lock to GPU base clocks.
+    PreferConsistentPerformance,
+}
+
+impl PowerMizerMode {
+    /// Returns the C constant equivalent for the given Rust enum variant.
+    pub fn as_c(&self) -> c_uint {
+        match *self {
+            Self::Adaptive => NVML_POWER_MIZER_MODE_ADAPTIVE,
+            Self::PreferMaximumPerformance => NVML_POWER_MIZER_MODE_PREFER_MAXIMUM_PERFORMANCE,
+            Self::Auto => NVML_POWER_MIZER_MODE_AUTO,
+            Self::PreferConsistentPerformance => {
+                NVML_POWER_MIZER_MODE_PREFER_CONSISTENT_PERFORMANCE
+            }
+        }
+    }
+}
+
+impl TryFrom<c_uint> for PowerMizerMode {
+    type Error = NvmlError;
+
+    fn try_from(data: c_uint) -> Result<Self, Self::Error> {
+        match data {
+            NVML_POWER_MIZER_MODE_ADAPTIVE => Ok(Self::Adaptive),
+            NVML_POWER_MIZER_MODE_PREFER_MAXIMUM_PERFORMANCE => Ok(Self::PreferMaximumPerformance),
+            NVML_POWER_MIZER_MODE_AUTO => Ok(Self::Auto),
+            NVML_POWER_MIZER_MODE_PREFER_CONSISTENT_PERFORMANCE => {
+                Ok(Self::PreferConsistentPerformance)
+            }
+            _ => Err(NvmlError::UnexpectedVariant(data)),
+        }
+    }
+}
+
 /// Returned by [`crate::Device::architecture()`].
 ///
 /// This is the simplified chip architecture of the device.

--- a/nvml-wrapper/src/structs/device.rs
+++ b/nvml-wrapper/src/structs/device.rs
@@ -134,9 +134,7 @@ pub struct PowerManagementConstraints {
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct PowerMizerModeInfo {
-    /// Current PowerMizer mode for the `Device`.
     pub current: PowerMizerMode,
-    /// Supported PowerMizer modes for the `Device`.
     pub supported: PowerMizerModes,
 }
 

--- a/nvml-wrapper/src/structs/device.rs
+++ b/nvml-wrapper/src/structs/device.rs
@@ -1,6 +1,8 @@
+use crate::bitmasks::device::PowerMizerModes;
 #[cfg(target_os = "windows")]
 use crate::enum_wrappers::device::DriverModel;
 use crate::enum_wrappers::device::OperationMode;
+use crate::enums::device::PowerMizerMode;
 #[cfg(feature = "serde")]
 use serde_derive::{Deserialize, Serialize};
 
@@ -126,6 +128,16 @@ pub struct OperationModeState {
 pub struct PowerManagementConstraints {
     pub min_limit: u32,
     pub max_limit: u32,
+}
+
+/// Returned from `Device.power_mizer_mode()`.
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct PowerMizerModeInfo {
+    /// Current PowerMizer mode for the `Device`.
+    pub current: PowerMizerMode,
+    /// Supported PowerMizer modes for the `Device`.
+    pub supported: PowerMizerModes,
 }
 
 /// Returned from `Device.encoder_stats()`

--- a/nvml-wrapper/src/test_utils.rs
+++ b/nvml-wrapper/src/test_utils.rs
@@ -10,6 +10,7 @@ use crate::enum_wrappers::device::*;
 use crate::enums::device::BusType;
 use crate::enums::device::DeviceArchitecture;
 use crate::enums::device::PcieLinkMaxSpeed;
+use crate::enums::device::PowerMizerMode;
 use crate::enums::device::PowerSource;
 use crate::enums::unit::*;
 use crate::error::NvmlError;
@@ -94,6 +95,9 @@ impl ShouldPrint for UtilizationInfo {}
 impl ShouldPrint for EccModeState {}
 impl ShouldPrint for OperationModeState {}
 impl ShouldPrint for InfoRom {}
+impl ShouldPrint for PowerMizerMode {}
+impl ShouldPrint for PowerMizerModeInfo {}
+impl ShouldPrint for PowerMizerModes {}
 impl ShouldPrint for Vec<RetiredPage> {}
 impl ShouldPrint for ExcludedDeviceInfo {}
 impl ShouldPrint for MemoryInfo {}


### PR DESCRIPTION
Hi,
this pr adds support for nvmlDeviceGetPowerMizerMode_v1/nvmlDeviceSetPowerMizerMode_v1 introduced along v580 driver. tested locally on 595/Ada gpu. Let me know if I missed anything