### PR TITLE
feat: Allow GpmSample to be reconstructed from the raw handle

### DIFF
--- a/nvml-wrapper/src/gpm.rs
+++ b/nvml-wrapper/src/gpm.rs
@@ -50,6 +50,15 @@ impl<'nvml> GpmSample<'nvml> {
         }
     }
 
+    /// Wrap a raw sample handle.
+    ///
+    /// # Safety
+    ///
+    /// You need to ensure that the sample is valid.
+    pub unsafe fn from_handle(nvml: &'nvml Nvml, sample: nvmlGpmSample_t) -> Self {
+        Self { sample, nvml }
+    }
+
     /**
     Use this to free the sample if you care about handling potential errors
     (*the `Drop` implementation ignores errors!*).


### PR DESCRIPTION
Use case: I have a `Nvml` with a non-static lifetime, and I want to keep a sample in memory until I get the next one.
Dealing with the non-static lifetimes everywhere is troublesome...

If there was a way to keep the raw sample and convert it when needed, it would work. Unfortunately, there's no way to do this for the moment.

GpmSample -> raw sample: ok
raw sample -> GpmSample: not ok

This PR solves the problem by adding `GpmSample::from_handle`.